### PR TITLE
Undo ClassMethods changes

### DIFF
--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -28,36 +28,36 @@ module Delayed
       warn '[DEPRECATION] `object.send_at(time, :method)` is deprecated. Use `object.delay(:run_at => time).method'
       __delay__(:run_at => time).__send__(method, *args)
     end
-  end
 
-  module ClassMethods
-    def handle_asynchronously(method, opts = {}) # rubocop:disable PerceivedComplexity
-      aliased_method = method.to_s.sub(/([?!=])$/, '')
-      punctuation = $1 # rubocop:disable PerlBackrefs
-      with_method = "#{aliased_method}_with_delay#{punctuation}"
-      without_method = "#{aliased_method}_without_delay#{punctuation}"
-      define_method(with_method) do |*args|
-        curr_opts = opts.clone
-        curr_opts.each_key do |key|
-          next unless (val = curr_opts[key]).is_a?(Proc)
-          curr_opts[key] = if val.arity == 1
-            val.call(self)
-          else
-            val.call
+    module ClassMethods
+      def handle_asynchronously(method, opts = {}) # rubocop:disable PerceivedComplexity
+        aliased_method = method.to_s.sub(/([?!=])$/, '')
+        punctuation = $1 # rubocop:disable PerlBackrefs
+        with_method = "#{aliased_method}_with_delay#{punctuation}"
+        without_method = "#{aliased_method}_without_delay#{punctuation}"
+        define_method(with_method) do |*args|
+          curr_opts = opts.clone
+          curr_opts.each_key do |key|
+            next unless (val = curr_opts[key]).is_a?(Proc)
+            curr_opts[key] = if val.arity == 1
+              val.call(self)
+            else
+              val.call
+            end
           end
+          delay(curr_opts).__send__(without_method, *args)
         end
-        delay(curr_opts).__send__(without_method, *args)
-      end
 
-      alias_method without_method, method
-      alias_method method, with_method
+        alias_method without_method, method
+        alias_method method, with_method
 
-      if public_method_defined?(without_method)
-        public method
-      elsif protected_method_defined?(without_method)
-        protected method
-      elsif private_method_defined?(without_method)
-        private method
+        if public_method_defined?(without_method)
+          public method
+        elsif protected_method_defined?(without_method)
+          protected method
+        elsif private_method_defined?(without_method)
+          private method
+        end
       end
     end
   end

--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -30,7 +30,7 @@ module Delayed
     end
   end
 
-  module MessageSendingClassMethods
+  module ClassMethods
     def handle_asynchronously(method, opts = {}) # rubocop:disable PerceivedComplexity
       aliased_method = method.to_s.sub(/([?!=])$/, '')
       punctuation = $1 # rubocop:disable PerlBackrefs

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -20,4 +20,4 @@ require 'delayed/deserialization_error'
 require 'delayed/railtie' if defined?(Rails::Railtie)
 
 Object.send(:include, Delayed::MessageSending)
-Module.send(:include, Delayed::MessageSendingClassMethods)
+Module.send(:include, Delayed::ClassMethods)

--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -20,4 +20,4 @@ require 'delayed/deserialization_error'
 require 'delayed/railtie' if defined?(Rails::Railtie)
 
 Object.send(:include, Delayed::MessageSending)
-Module.send(:include, Delayed::ClassMethods)
+Module.send(:include, Delayed::MessageSending::ClassMethods)

--- a/spec/message_sending_spec.rb
+++ b/spec/message_sending_spec.rb
@@ -1,11 +1,6 @@
 require 'helper'
 
 describe Delayed::MessageSending do
-  it 'does not include ClassMethods along with MessageSending' do
-    expect { ClassMethods }.to raise_error(NameError)
-    expect(defined?(String::ClassMethods)).to eq(nil)
-  end
-
   describe 'handle_asynchronously' do
     class Story
       def tell!(_arg); end


### PR DESCRIPTION
So.... funny backstory behind this: delayed_job (4.1.3) broke bridges which was only caught by solitude_reports specs (very very many `NoMethodError`s) like so:
 
```
EngagementQualityCalculation#check! ...
     Failure/Error: calculation.check!
     NoMethodError:
       undefined method `find' for Bridges::Creative:Class
```

Now, this PR contains reversing the offending commits. @ajvondrak since you're more familiar with bridges and it's metaprogramming, maybe you can discern why these changes would cause problems. @hsujeremyc just in-case you were curious what was going on. 